### PR TITLE
Explicit 'Custom' context type and permit queries to override defaults

### DIFF
--- a/etc_search.php
+++ b/etc_search.php
@@ -42,20 +42,20 @@ function etc_search_install($event='', $step='')
 		if(!safe_count('txp_form', "name = 'etc_search_results' AND type = 'article'"))
 			safe_insert("txp_form", "name = 'etc_search_results', type = 'article', Form = '<txp:permlink><txp:title /></txp:permlink>'");
 
-		$qc="CREATE TABLE IF NOT EXISTS ".safe_pfx('etc_search')." (";
-		$qc.= <<<EOF
-			`id` int(4) NOT NULL AUTO_INCREMENT,
-			`query` varchar(255) NOT NULL,
-			`form1` varchar(64) NOT NULL,
-			`form2` varchar(64) NOT NULL,
-			`thing1` text NOT NULL,
-			`thing2` text NOT NULL,
-			`type` enum('article','image','file','link','category','section') NOT NULL,
-			PRIMARY KEY (`id`)
-			) ENGINE=MyISAM CHARACTER SET=utf8 ;
-EOF;
-		safe_query($qc);
-		safe_alter('etc_search', "MODIFY `type` enum('article','image','file','link','category','section') NOT NULL");
+		safe_create('etc_search', "
+			id		INT(4)			NOT NULL AUTO_INCREMENT,
+			query	VARCHAR(255)	NOT NULL,
+			form1	VARCHAR(64)		NOT NULL,
+			form2	VARCHAR(64)		NOT NULL,
+			thing1	TEXT			NOT NULL,
+			thing2	TEXT			NOT NULL,
+			type	ENUM('article','image','file','link','category','section','custom') NOT NULL,
+			PRIMARY KEY (id)
+		");
+
+		safe_alter('etc_search', "MODIFY `type` enum('article','image','file','link','category','section','custom') NOT NULL");
+		safe_update('etc_search', "type = 'custom'", "type = ''");
+
 		return;
 	}
 }
@@ -119,7 +119,7 @@ function etc_search_form($row) {
 	echo '<h3 class="lever txp-summary"><a href="#etc-form-'.$row['id'].'">', ($row['id'] ? 'Search form '.$row['id'] : 'New search form'), '</a></h3>', n;
 	echo '<form id="etc-form-'.$row['id'].'" class="etc-search-form" method="post" action="?event=etc_search#etc-form-'.$row['id'].'"', ($row['id'] ? ' data-id="'.$row['id'].'"' : ''), '>', n;
 	echo '<p><label>context</label><br />', /*implode('&nbsp;&nbsp; ', $context)*/
-	radioSet(array('article'=>gTxt('article_context'), 'image'=>gTxt('image_context'), 'file'=>gTxt('file_context'), 'link'=>gTxt('link_context'), 'category'=>gTxt('category'), 'section'=>gTxt('section'), ''=>'custom'), 'type', $row['type'], '', 'etc-'.$row['id']), '</p>', n;
+	radioSet(array('article'=>gTxt('article_context'), 'image'=>gTxt('image_context'), 'file'=>gTxt('file_context'), 'link'=>gTxt('link_context'), 'category'=>gTxt('category'), 'section'=>gTxt('section'), 'custom'=>'custom'), 'type', $row['type'], '', 'etc-'.$row['id']), '</p>', n;
 	echo '<p><label>query</label><br /><input type="text" name="query" value="', $row['query'], '" placeholder="{', $search_fields, '}" /></p>', n;
 	echo '<p><label>logical operators (JSON-encoded)</label><br /><input type="text" name="etc_ops_',$row['id'],'" value="', $row['id'] ? doSpecial(get_pref('etc_search_ops_'.$row['id'])) : '', '" placeholder="',doSpecial(get_pref('etc_search_ops')),'" /></p>', n;
 	echo '<table class="etc-two-column"><tr>', n;

--- a/etc_search.php
+++ b/etc_search.php
@@ -300,6 +300,11 @@ function etc_search_get_results($params, $live=true)
 			$query = $matches[1]; $order = $matches[2];
 		} else $order = '';
 
+		// If $query includes an own 'Status' query, use that in place of the default
+		if(preg_match('/^(.+)\b(Status[\s!=<>].+)$/Ui', $query, $matches)) {
+			$status = '';
+		} else $status = 'Status >= 4 AND';
+
 		$etc_search_match = true;
 		$etc_search_match_query = false;
 		$query = preg_replace_callback('/\{((?:[^{}]|(?0))+)\}/U', 'etc_search_gps', $oldquery = $query);
@@ -311,8 +316,8 @@ function etc_search_get_results($params, $live=true)
 		if(!($custom = preg_match('/^SELECT\b/i', $query))) switch($type) {//default search
 			case 'image' : case 'file' : case 'link' : case 'category' : case 'section' :
 			$table = safe_pfx('txp_'.$type);
-			$count = 'SELECT COUNT(*) FROM '.$table.' WHERE '.($type == 'file' ? 'status >= 4 AND ' : '').$query;
-			$query = 'SELECT * FROM '.$table.' WHERE '.($type == 'file' ? 'status >= 4 AND ' : '').$query;
+			$count = 'SELECT COUNT(*) FROM '.$table.' WHERE '.($type == 'file' ? $status.' ' : '').$query;
+			$query = 'SELECT * FROM '.$table.' WHERE '.($type == 'file' ? $status.' ' : '').$query;
 			break;
 
 			default :
@@ -324,8 +329,8 @@ function etc_search_get_results($params, $live=true)
 			$table = safe_pfx('textpattern');
 			$now_posted = is_callable('now') ? now('posted') : 'NOW()';
 			$now_expires = is_callable('now') ? now('expires') : 'NOW()';
-			$count = "SELECT COUNT(*) FROM $table WHERE Status >= 4 AND Posted <= $now_posted AND (Expires IS NULL OR Expires>=$now_expires) $s_filter AND $query";
-			$query = "SELECT *".($order ? '' : ", MATCH ($safe_search_fields) AGAINST ('$q') AS score")." FROM $table WHERE Status >= 4 AND Posted <= $now_posted AND (Expires IS NULL OR Expires>=$now_expires) $s_filter AND $query";
+			$count = "SELECT COUNT(*) FROM $table WHERE $status Posted <= $now_posted AND (Expires IS NULL OR Expires>=$now_expires) $s_filter AND $query";
+			$query = "SELECT *".($order ? '' : ", MATCH ($safe_search_fields) AGAINST ('$q') AS score")." FROM $table WHERE $status Posted <= $now_posted AND (Expires IS NULL OR Expires>=$now_expires) $s_filter AND $query";
 			if(!$order) $order = ' ORDER BY score DESC';
 		}
 


### PR DESCRIPTION
- Add 'custom' as ENUM type to database, including table updates on upgrade and setting option in radio-buttons
- Permit search queries to include own “Status” conditions (the default remains Status >= 4 if not defined)
- Permit search queries to search in sections that are normally not searchable if explicitly specified in the search query

I can't see how to make separate PRs from individual commits without making branches, so if you prefer I can make upcoming PRs separately so that further commits don't keep getting added to this one.

Upcoming stuff:
- a textpack and corresponding gTxt strings for better localisation
- help text additions
- some minor tag UI revisions